### PR TITLE
Added parser for .NET Core build files and date-agnostic parsing

### DIFF
--- a/logdissect/parsers/__init__.py
+++ b/logdissect/parsers/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 __all__ = ['syslog', 'syslogiso', 'syslognohost', 'linejson', 'tcpdump',
-        'ciscoios', 'windowsrsyslog', 'sojson', 'webaccess', 'emerge']
+        'ciscoios', 'windowsrsyslog', 'sojson', 'webaccess', 'emerge', 'dotnetDefault']
 
 import logdissect.parsers.blank
 import logdissect.parsers.linejson
@@ -34,3 +34,4 @@ import logdissect.parsers.ciscoios
 import logdissect.parsers.windowsrsyslog
 import logdissect.parsers.webaccess
 import logdissect.parsers.emerge
+import logdissect.parsers.dotnetDefault

--- a/logdissect/parsers/dotnetDefault.py
+++ b/logdissect/parsers/dotnetDefault.py
@@ -1,0 +1,17 @@
+from logdissect.parsers.type import ParseModule as OurModule
+
+class ParseModule(OurModule):
+    def __init__(self, options=[]):
+        """Initialize the .Net Core parsing module"""
+        self.name = 'dotnetDefault'
+        self.desc = '.Net Core Build parsing module'
+        self.format_regex = \
+                '^(?:\s+)?(?:\d+>)?(.*?)(?:\((\d+),(\d+)\))?:\s+(\w+)\s+(\w+\d+):\s+(.*)$'
+        self.fields = ["filepath","line_number","column_number","log_type","error_code","description"]
+
+        self.backup_format_regex = None
+        self.backup_fields = []
+        self.tzone = None
+        self.datestamp_type = None
+        self.time_ordering = False
+        self.numeric_time_ordering = False 

--- a/logdissect/utils.py
+++ b/logdissect/utils.py
@@ -206,7 +206,7 @@ def merge_logs(dataset, sort=True):
     ourlog['entries'] = []
     for d in dataset:
         ourlog['entries'] = ourlog['entries'] + d['entries']
-    if sort:
+    if sort and all('numeric_date_stamp_utc' in entry for entry in ourlog['entries']):
         ourlog['entries'].sort(key= lambda x: x['numeric_date_stamp_utc'])
 
     return ourlog


### PR DESCRIPTION
### New Functionality

- Added a new parser specifically designed to handle .NET Core build files
- Implemented date-agnostic parsing logic to handle logs that do not contain explicit timestamps. This allows the parser to function correctly with build logs from various sources, including those that lack standard date formatting.

### Fixes

- Resolved an issue where the parser would fail when encountering build logs without dates, making it more robust and versatile for different use cases

### Related Issues

- None at this time.